### PR TITLE
Remove empty format precision specifier

### DIFF
--- a/input.rs
+++ b/input.rs
@@ -58,7 +58,7 @@ fn fix_line(t: &str) -> String {
     let mut words: Vec<String> = vec![];
     for word in t.split_whitespace() {
         words.push(match f64::from_str(word) {
-            Ok(v) if word.contains("e") => format!("{:.}", v),
+            Ok(v) if word.contains("e") => format!("{}", v),
             _ => String::from(word),
         });
     }


### PR DESCRIPTION
A format precision specifier consisting of a dot and no number actually does nothing and has no specified meaning. Currently this is silently ignored, but it may turn into a warning or error.

See rust-lang/rust#131159 and rust-lang/rust#136638

Please leave a comment there if you have any opinion about this. If you remember why this was written this way that could help improve the diagnostics rustc gives.